### PR TITLE
Version 0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,12 +3,12 @@ uuid = "d842c3ba-07a1-494f-bbec-f5741b0a3e98"
 authors = ["Zachary Sunberg <sunbergzach@gmail.com> and contributors"]
 version = "0.1.0"
 
-# [deps]
-# MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+[deps]
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]
-# MacroTools = "0.5"
 julia = "1.4"
+MacroTools = "0.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,30 @@ actions(env)    # returns the set of all possible actions for the environment
 
 ## Optional Interface
 
-In the near future, a number of optional interface functions will be added. Please file an issue if you would like to see a particular interface function.
+There are several additional functions that are currently optional:
+- `clone`
+- `render`
+- `valid_actions`
+- `valid_action_mask`
+- `observations`
+
+To see documentation for one of these functions, use [Julia's built-in help system](https://docs.julialang.org/en/v1/manual/documentation/index.html#Accessing-Documentation-1).
+
+To indicate that an environment that you created implements one of these optional functions, use the `@provide` macro, e.g.
+```julia
+@provide CommonRLInterface.clone(env::MyEnv) = deepcopy(env)
+```
+
+To check whether an optional function has been implemented for an environment, use `provided`, e.g.
+```julia
+if provided(valid_actions, env)
+    acts = valid_actions(env)
+else
+    acts = actions(env)
+end
+```
+
+To propose adding a new function to the interface, please file an issue with the "candidate interface function" label.
 
 ## Additional info
 
@@ -40,9 +63,9 @@ Suppose you have an abstract environment type in your package called `YourEnv`. 
 2. You provide an implementation of the interface functions from your framework only using functions from CommonRLInterface
 
 4. You implement at minimum
-    - `CommonRL.reset!(::YourCommonEnv)`
-    - `CommonRL.step!(::YourCommonEnv, a)`
-    - `CommonRL.actions(::YourCommonEnv)`
+    - `CommonRLInterface.reset!(::YourCommonEnv)`
+    - `CommonRLInterface.step!(::YourCommonEnv, a)`
+    - `CommonRLInterface.actions(::YourCommonEnv)`
     and as many optional functions as you'd like to support, where `YourCommonEnv` is the concrete type returned by `convert(Type{AbstractEnv}, ::YourEnv)`
 
 ### What does an environment implementation look like?

--- a/src/CommonRLInterface.jl
+++ b/src/CommonRLInterface.jl
@@ -35,8 +35,6 @@ TODO: document concept of a set.
 """
 function actions end
 
-# Below to be enabled in v0.2
-#=
 export
     provided,
     @provide
@@ -88,19 +86,16 @@ macro provide(f)
     end
 end
 
-## Optional Functions ##
-# In the future, these will go in separate files
+export
+    clone,
+    render
+include("environment.jl")
 
-export clone
+export
+    observations,
+    valid_actions,
+    valid_action_mask
+include("spaces.jl")
 
-"""
-    clone(env)
-
-Create a clone of CommonEnv `env` at the current state.
-
-Two clones are assumed to be completely independent of each other - no action applied to one will affect the other.
-"""
-function clone end
-=#
 
 end

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -1,0 +1,16 @@
+"""
+    clone(env)
+
+Create a clone of CommonEnv `env` at the current state.
+
+Two clones are assumed to be completely independent of each other - no action applied to one will affect the other.
+"""
+function clone end
+
+"""
+    render(env)
+
+Return a showable object that visualizes the environment at the current state.
+
+Implementing this function will facilitate visualization through the [Julia Multimedia I/O system](https://docs.julialang.org/en/v1/base/io-network/#Multimedia-I/O-1), for example, calling `display(render(env))` will cause the visualization to pop up in a Jupyter notebook, the Juno plot pane, or an ElectronDisplay.jl window. `render` should return an object that has `Base.show` methods for many MIME types. Good examples include a Plots.jl plot, a Compose.jl `Context` graphic produced by Cairo, or a custom type
+"""

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -12,5 +12,18 @@ function clone end
 
 Return a showable object that visualizes the environment at the current state.
 
-Implementing this function will facilitate visualization through the [Julia Multimedia I/O system](https://docs.julialang.org/en/v1/base/io-network/#Multimedia-I/O-1), for example, calling `display(render(env))` will cause the visualization to pop up in a Jupyter notebook, the Juno plot pane, or an ElectronDisplay.jl window. `render` should return an object that has `Base.show` methods for many MIME types. Good examples include a Plots.jl plot, a Compose.jl `Context` graphic produced by Cairo, or a custom type
+Implementing this function will facilitate visualization through the [Julia Multimedia I/O system](https://docs.julialang.org/en/v1/base/io-network/#Multimedia-I/O-1), for example, calling `display(render(env))` will cause the visualization to pop up in a Jupyter notebook, the Juno plot pane, or an ElectronDisplay.jl window. `render` should return an object that has `Base.show` methods for many MIME types. Good examples include a Plots.jl plot, a Compose.jl `Context` graphic produced by Cairo, or a custom type with `show` methods.
+
+# Example
+```
+using CommonRLInterface
+using Plots
+
+struct MyEnv <: AbstractEnv
+    state::Tuple{Int, Int}
+env
+
+@provide CommonRLInterface.render(env::MyEnv) = scatter(env.state[1], env.state[2])
+```
 """
+function render end

--- a/src/spaces.jl
+++ b/src/spaces.jl
@@ -1,0 +1,24 @@
+"""
+    valid_actions(env)
+
+Return a collection of actions that are appropriate for the current state.
+
+This should be a subset of actions(env).
+"""
+function valid_actions end
+
+"""
+    valid_action_mask(env)
+
+Return a mask (any `AbstractArray{Bool}`) indicating which actions are valid.
+
+This function only applies to environments with finite action spaces. If both `valid_actions` and `valid_action_mask` are provided, `valid_actions(env)` should return the same set as `actions(env)[valid_action_mask(env)]`.
+"""
+function valid_action_mask end
+
+"""
+    observations(env)
+
+Return a collection of all observations that might be returned by `step!(env)` or `reset!(env)`.
+"""
+function observations end


### PR DESCRIPTION
Added `@provide` to fix #1 

Added the following functions
- `valid_actions` fixes #8 
- `clone` fixes #2 
- `observations` fixes #10 
- `valid_action_mask` fixes #19 
- `render` fixes #21 

I did not include `setstate!` #9 , yet, because there is still a question about whether we want that or `reset!(env, state)`.

I did not add `observe` #12 yet, because I don't understand the exact semantics of it. If someone can write a docstring for it that is unambiguous from both the environment writer and algorithm writer's perspective, then I think we could add it.

I did not set up Documenter.jl docs yet #24 , but I don't think this is necessary to be useful to release.