### PR TITLE
Added AutomaticDefault module

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [targets]
-test = ["Test", "ColorSchemes", "Compose", "StaticArrays"]
+test = ["Test", "ColorSchemes", "Compose", "StaticArrays", "Documenter"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,6 +16,7 @@ makedocs(;
         "required.md",
         "multiplayer.md",
         "optional.md",
+        "interacting.md",
         "wrappers.md",
         "faqs.md"
     ],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,5 +11,5 @@ Example environments can be found in the [examples directory on GitHub](https://
 Detailed reference documentation can be found using the links below:
 
 ```@contents
-Pages = ["required.md", "multiplayer.md", "optional.md", "wrappers.md", "faqs.md"]
+Pages = ["required.md", "multiplayer.md", "optional.md", "interacting.md", "wrappers.md", "faqs.md"]
 ```

--- a/docs/src/interacting.md
+++ b/docs/src/interacting.md
@@ -1,0 +1,9 @@
+# Interacting with Environments
+
+Users who wish to run simulations or implement reinforcement learning algorithms with environments that others have defined should interact with environments using functions from the [Required Interface](@ref) and [Optional Interface](@ref).
+
+In order to achieve compatibility with the widest possible set of environments, it is critical to handle environments with incomplete implementations of the [Optional Interface](@ref) gracefully. The [`AutomaticDefault`](@ref) module provides functions that have default implementations based on other functions when possible, so users can call them without worrying about which optional functions the environment implements. For this reason, RL algorithm implementers should use [`AutomaticDefault`](@ref) unless there is a compelling reason not to.
+
+```@docs
+AutomaticDefault
+```

--- a/docs/src/optional.md
+++ b/docs/src/optional.md
@@ -4,6 +4,9 @@ Some environments can provide additional information or behavior beyond what can
 
 ## Determining what an environment has: `provided`
 
+!!! tip 
+    The [`AutomaticDefault`](@ref) module provides a convenient way to access optional functions that is an alternative to calling `provided` manually.
+
 When other code interacts with an environment, it is common to adjust behavior based on the capabilities that environment provides. The [`provided`](@ref) function is a programmatic way to determine whether the environment author has implemented certain optional behavior. For instance, an algorithm author might only want to consider the valid subset of actions at the current state if the `valid_actions` optional function is implemented. This can be accomplished with the following code:
 ```julia
 if provided(valid_actions, env)
@@ -12,7 +15,7 @@ else
     acts = actions(env)
 end
 ```
-In most cases, `provided` can be statically optimized out, so it will have no performance impact.
+(or by using [`AutomaticDefault`](@ref)`.valid_actions`). In most cases, `provided` can be statically optimized out, so it will have no performance impact.
 
 ## Optional Function List
 

--- a/examples/rock_paper_scissors.jl
+++ b/examples/rock_paper_scissors.jl
@@ -23,7 +23,7 @@ beats(a, b) = (a==:rock && b==:scissors) || (a==:scissors && b==:paper) || (a==:
     end
 end
 
-RL.actions(env::RockPaperScissors, player=0) = (:rock, :paper, :scissors)
+RL.actions(env::RockPaperScissors) = (:rock, :paper, :scissors)
 RL.terminated(env::RockPaperScissors) = env.status == :done
 RL.reset!(env::RockPaperScissors) = env.status = :start
 @provide RL.players(env::RockPaperScissors) = 1:2

--- a/examples/tictactoe.jl
+++ b/examples/tictactoe.jl
@@ -17,7 +17,7 @@ iswinner(b, p) = any(all(b[i,:].==p) for i in 1:3) ||
 other(p) = mod1(p+1,2)
 
 RL.reset!(env::TicTacToe) = fill!(env.board, 0)
-RL.actions(env::TicTacToe, player=0) = vec([(i, j) for i in 1:3, j in 1:3])
+RL.actions(env::TicTacToe) = vec([(i, j) for i in 1:3, j in 1:3])
 # symmetrical observations for both players: +1 for your square, -1 for other square
 RL.observe(env::TicTacToe) = zeros(Int, 3, 3) + (env.board.==player(env)) - (env.board.==other(player(env)))
 RL.terminated(env::TicTacToe) = any(iswinner(env.board, p) for p in 1:2) || all(env.board .!= 0)

--- a/src/CommonRLInterface.jl
+++ b/src/CommonRLInterface.jl
@@ -139,6 +139,10 @@ export
 include("multiplayer.jl")
 
 export
+    AutomaticDefault
+include("automatic_default.jl")
+
+export
     Wrappers
 include("wrappers.jl")
 

--- a/src/CommonRLInterface.jl
+++ b/src/CommonRLInterface.jl
@@ -110,8 +110,8 @@ If this returns true, it means that the function is provided for any set of argu
 """
 function provided end
 
-provided(f::Function, args...) = provided(f, typeof(args))
-provided(f::Function, T::Type{<:Tuple}) = Tricks.static_hasmethod(f, T)
+provided(f::Union{Function, DataType}, args...) = provided(f, typeof(args))
+provided(f::Union{Function, DataType}, T::Type{<:Tuple}) = Tricks.static_hasmethod(f, T)
 
 export
     clone,

--- a/src/CommonRLInterface.jl
+++ b/src/CommonRLInterface.jl
@@ -1,5 +1,7 @@
 module CommonRLInterface
 
+using MacroTools
+
 export
     AbstractEnv,
     reset!,

--- a/src/CommonRLInterface.jl
+++ b/src/CommonRLInterface.jl
@@ -1,7 +1,5 @@
 module CommonRLInterface
 
-using MacroTools
-
 export
     AbstractEnv,
     reset!,
@@ -89,116 +87,12 @@ If `terminated(env)` is true, no further actions should be taken and it is safe 
 """
 function terminated end
 
-export
-    provided,
-    @provide
+include("optional.jl")
 
-"""
-    provided(f, args...)
+export AutomaticDefault
+include("automatic_default.jl")
 
-Test whether an implementation for `f(args...)` has been provided.
-
-If this returns false, you should assume that the environment does not support the function `f`.
-
-Usage is identical to `Base.applicable`, but unlike `Base.applicable`, `provided` can usually be inferred at compile time. This function is usually automatically implemented by the @provide macro. It should only be implemented by the user in exceptional cases where very fine control is needed.
-
----
-
-    provided(f, types::Type{<:Tuple})
-
-Alternate version of provided with syntax similar to `Base.hasmethod`.
-
-If this returns true, it means that the function is provided for any set of arguments with the given types. If it returns false, it may be provided for certain objects. For this reason, algorithm writers should call the `provided(f, args...)` version when possible.
-"""
-function provided end
-
-provided(f::Function, args...) = provided(f, typeof(args))
-provided(f::Function, ::Type{<:Tuple}) = false
-
-provided(::typeof(reset!), ::Type{<:Tuple{AbstractEnv}}) = true
-provided(::typeof(actions), ::Type{<:Tuple{AbstractEnv}}) = true
-provided(::typeof(observe), ::Type{<:Tuple{AbstractEnv}}) = true
-provided(::typeof(act!), ::Type{<:Tuple{AbstractEnv, Any}}) = true
-
-"""
-    @provide f(x::X) = x^2
-
-Indicate that function `f` has been implemented for arguments of type `X`.
-
-This will automatically implement the appropriate methods of `provided`. Both the long and short function definition forms will work.
-
-# Example
-```jldoctest
-using CommonRLInterface
-
-struct MyEnv <: AbstractEnv
-    s::Int
-end
-
-# Initially, clone is not provided
-@assert !provided(clone, MyEnv(1))
-
-@provide CommonRLInterface.clone(env::MyEnv) = MyEnv(env.s)
-
-@assert provided(clone, MyEnv(1))
-
-clone(MyEnv(1))
-
-# output
-
-MyEnv(1)
-
-```
-"""
-macro provide(f)
-    def = splitdef(f) # TODO: probably give a better error message that mentions @provide if this fails
-    @assert isempty(def[:kwargs]) "@provide does not support keyword args yet."
-    
-    func = esc(def[:name])
-
-    argtypes = []
-    for arg in def[:args]
-        if @capture(arg, name_::T_)
-            push!(argtypes, esc(T))
-        else
-            push!(argtypes, :Any)
-        end
-    end
-    
-    quote
-        CommonRLInterface.provided(::typeof($func), ::Type{<:Tuple{$(argtypes...)}}) where {$(map(esc, def[:whereparams])...)} = true
-
-        $(esc(f))
-    end
-end
-
-export
-    clone,
-    render,
-    state,
-    setstate!
-include("environment.jl")
-
-export
-    observations,
-    valid_actions,
-    valid_action_mask
-include("spaces.jl")
-
-export
-    players,
-    player,
-    all_act!,
-    all_observe,
-    UtilityStyle,
-    ZeroSum,
-    ConstantSum,
-    GeneralSum,
-    IdenticalUtility
-include("multiplayer.jl")
-
-export
-    Wrappers
+export Wrappers
 include("wrappers.jl")
 
 end

--- a/src/automatic_default.jl
+++ b/src/automatic_default.jl
@@ -1,0 +1,77 @@
+module AutomaticDefault
+
+using CommonRLInterface
+
+export
+    clone,
+    valid_actions,
+    valid_action_mask
+    
+# Environment
+
+function clone(env)
+    if provided(CommonRLInterface.clone, env)
+        return CommonRLInterface.clone(env)
+    else
+        return deepcopy(env)
+    end
+end
+
+# Spaces
+
+function actions(env, player)
+    if provided(CommonRLInterface.actions, env, player)
+        return CommonRLInterface.actions(env, player)
+    else
+        return CommonRLInterface.actions(env)
+    end
+end
+
+function valid_actions(env)
+    if provided(CommonRLInterface.valid_actions, env)
+        return CommonRLInterface.valid_actions(env)
+    elseif provided(CommonRLInterface.valid_action_mask, env)
+        return actions(env)[CommonRLInterface.valid_action_mask(env)]
+    elseif provided(CommonRLInterface.actions, env, player(env))
+        return CommonRLInterface.actions(env, player(env))
+    else
+        return actions(env)
+    end
+end
+
+function valid_action_mask(env)
+    if provided(CommonRLInterface.valid_action_mask, env)
+        return CommonRLInterface.valid_action_mask(env)
+    elseif provided(CommonRLInterface.valid_actions, env)
+        return map(in(CommonRLInterface.valid_actions(env)), actions(env))
+    else
+        return trues(length(actions(env)))
+    end
+end
+
+# Multiplayer
+function players(env)
+    if provided(CommonRLInterface.players, env)
+        return CommonRLInterface.players(env)
+    else
+        return 1
+    end
+end
+
+function player(env)
+    if provided(CommonRLInterface.player, env)
+        return CommonRLInterface.player(env)
+    else
+        return 1
+    end
+end
+
+function UtilityStyle(env)
+    if provided(CommonRLInterface.UtilityStyle, env)
+        return CommonRLInterface.UtilityStyle(env)
+    else
+        return GeneralSum()
+    end
+end
+
+end

--- a/src/automatic_default.jl
+++ b/src/automatic_default.jl
@@ -1,3 +1,31 @@
+"""
+The `CommonRLInterface.AutomaticDefault` module contains a complete copy of all of the functions in `CommonRLInterface`, with the crucial difference that each of the functions will try as hard as possible to return a default value.
+
+For example, if the environment does not have [`CommonRLInterface.clone`](@ref) implemented for it, `AutomaticDefault.clone` will fall back to `deepcopy`, and if [`CommonRLInterface.valid_actions`](@ref) is implemented, then `AutomaticDefault.valid_action_mask` will automatically work consistently.
+
+Environment *implementers* should implement new methods for functions in `CommonRLInterface` and should not deal with `AutomaticDefault`; environment *users* (e.g. RL algorithm implementers) should use [`AutomaticDefault`](@ref) for the widest compatibility possible with different environments (or use [`CommonRLInterface.provided`](@ref) to manually adapt to the environment's capabilities).
+
+# Example
+```jldoctest
+import CommonRLInterface
+using CommonRLInterface.AutomaticDefault
+using Test
+
+struct ExampleEnv <: CommonRLInterface.AbstractEnv end
+
+CommonRLInterface.actions(::ExampleEnv) = 1:2
+
+# CommonRLInterface.valid_actions will not work, because valid_actions was not defined 
+@test_throws MethodError CommonRLInterface.valid_actions(ExampleEnv())
+
+# But, this version from AutomaticDefault will work by falling back to `actions`:
+valid_actions(ExampleEnv())
+
+# output
+
+1:2
+```
+"""
 module AutomaticDefault
 
 using CommonRLInterface
@@ -5,14 +33,45 @@ using CommonRLInterface
 const RL = CommonRLInterface
 
 export
-    clone,
+    reset!,
     actions,
+    observe,
+    act!,
+    terminated
+
+export
+    clone,
+    render,
+    state,
+    setstate!
+
+export
+    observations,
     valid_actions,
-    valid_action_mask,
+    valid_action_mask
+
+export
     players,
     player,
+    all_act!,
+    all_observe,
     UtilityStyle
     
+# Required
+
+reset! = RL.reset!
+actions(env) = RL.actions(env)
+function actions(env, player)
+    if provided(RL.actions, env, player)
+        return RL.actions(env, player)
+    else
+        return RL.actions(env)
+    end
+end
+observe = RL.observe
+act! = RL.act!
+terminated = RL.terminated
+
 # Environment
 
 function clone(env)
@@ -23,21 +82,19 @@ function clone(env)
     end
 end
 
+render = RL.render
+state = RL.state
+setstate! = RL.setstate!
+
 # Spaces
 
-function actions(env, player)
-    if provided(RL.actions, env, player)
-        return RL.actions(env, player)
-    else
-        return RL.actions(env)
-    end
-end
+observations = RL.observations
 
 function valid_actions(env)
     if provided(RL.valid_actions, env)
         return RL.valid_actions(env)
     elseif provided(RL.valid_action_mask, env)
-        return actions(env)[RL.valid_action_mask(env)]
+        return RL.actions(env)[RL.valid_action_mask(env)]
     elseif provided(RL.actions, env, player(env))
         return RL.actions(env, player(env))
     else
@@ -73,6 +130,9 @@ function player(env)
         return 1
     end
 end
+
+all_act! = RL.all_act!
+all_observe = RL.all_observe
 
 function UtilityStyle(env)
     if provided(RL.UtilityStyle, env)

--- a/src/automatic_default.jl
+++ b/src/automatic_default.jl
@@ -2,16 +2,22 @@ module AutomaticDefault
 
 using CommonRLInterface
 
+const RL = CommonRLInterface
+
 export
     clone,
+    actions,
     valid_actions,
-    valid_action_mask
+    valid_action_mask,
+    players,
+    player,
+    UtilityStyle
     
 # Environment
 
 function clone(env)
-    if provided(CommonRLInterface.clone, env)
-        return CommonRLInterface.clone(env)
+    if provided(RL.clone, env)
+        return RL.clone(env)
     else
         return deepcopy(env)
     end
@@ -20,55 +26,57 @@ end
 # Spaces
 
 function actions(env, player)
-    if provided(CommonRLInterface.actions, env, player)
-        return CommonRLInterface.actions(env, player)
+    if provided(RL.actions, env, player)
+        return RL.actions(env, player)
     else
-        return CommonRLInterface.actions(env)
+        return RL.actions(env)
     end
 end
 
 function valid_actions(env)
-    if provided(CommonRLInterface.valid_actions, env)
-        return CommonRLInterface.valid_actions(env)
-    elseif provided(CommonRLInterface.valid_action_mask, env)
-        return actions(env)[CommonRLInterface.valid_action_mask(env)]
-    elseif provided(CommonRLInterface.actions, env, player(env))
-        return CommonRLInterface.actions(env, player(env))
+    if provided(RL.valid_actions, env)
+        return RL.valid_actions(env)
+    elseif provided(RL.valid_action_mask, env)
+        return actions(env)[RL.valid_action_mask(env)]
+    elseif provided(RL.actions, env, player(env))
+        return RL.actions(env, player(env))
     else
-        return actions(env)
+        return RL.actions(env)
     end
 end
 
 function valid_action_mask(env)
-    if provided(CommonRLInterface.valid_action_mask, env)
-        return CommonRLInterface.valid_action_mask(env)
-    elseif provided(CommonRLInterface.valid_actions, env)
-        return map(in(CommonRLInterface.valid_actions(env)), actions(env))
+    if provided(RL.valid_action_mask, env)
+        return RL.valid_action_mask(env)
+    elseif provided(RL.valid_actions, env)
+        return map(in(RL.valid_actions(env)), actions(env))
+    elseif provided(RL.actions, env, player(env))
+        return map(in(RL.actions(env, player(env))), RL.actions(env))
     else
-        return trues(length(actions(env)))
+        return trues(length(RL.actions(env)))
     end
 end
 
 # Multiplayer
 function players(env)
-    if provided(CommonRLInterface.players, env)
-        return CommonRLInterface.players(env)
+    if provided(RL.players, env)
+        return RL.players(env)
     else
         return 1
     end
 end
 
 function player(env)
-    if provided(CommonRLInterface.player, env)
-        return CommonRLInterface.player(env)
+    if provided(RL.player, env)
+        return RL.player(env)
     else
         return 1
     end
 end
 
 function UtilityStyle(env)
-    if provided(CommonRLInterface.UtilityStyle, env)
-        return CommonRLInterface.UtilityStyle(env)
+    if provided(RL.UtilityStyle, env)
+        return RL.UtilityStyle(env)
     else
         return GeneralSum()
     end

--- a/src/optional.jl
+++ b/src/optional.jl
@@ -21,8 +21,8 @@ If this returns true, it means that the function is provided for any set of argu
 """
 function provided end
 
-provided(f::Function, args...) = provided(f, typeof(args))
-provided(f::Function, ::Type{<:Tuple}) = false
+provided(f, args...) = provided(f, typeof(args))
+provided(f, ::Type{<:Tuple}) = false
 
 provided(::typeof(reset!), ::Type{<:Tuple{AbstractEnv}}) = true
 provided(::typeof(actions), ::Type{<:Tuple{AbstractEnv}}) = true
@@ -67,7 +67,7 @@ macro provide(f)
 
     argtypes = []
     for arg in def[:args]
-        if @capture(arg, name_::T_)
+        if @capture(arg, name_::T_ | ::T_)
             push!(argtypes, esc(T))
         else
             push!(argtypes, :Any)
@@ -75,7 +75,7 @@ macro provide(f)
     end
     
     quote
-        CommonRLInterface.Optional.provided(::typeof($func), ::Type{<:Tuple{$(argtypes...)}}) where {$(map(esc, def[:whereparams])...)} = true
+        CommonRLInterface.provided(::typeof($func), ::Type{<:Tuple{$(argtypes...)}}) where {$(map(esc, def[:whereparams])...)} = true
 
         $(esc(f))
     end

--- a/src/optional.jl
+++ b/src/optional.jl
@@ -1,0 +1,107 @@
+export
+    provided,
+    @provide
+
+"""
+    provided(f, args...)
+
+Test whether an implementation for `f(args...)` has been provided.
+
+If this returns false, you should assume that the environment does not support the function `f`.
+
+Usage is identical to `Base.applicable`, but unlike `Base.applicable`, `provided` can usually be inferred at compile time. This function is usually automatically implemented by the @provide macro. It should only be implemented by the user in exceptional cases where very fine control is needed.
+
+---
+
+    provided(f, types::Type{<:Tuple})
+
+Alternate version of provided with syntax similar to `Base.hasmethod`.
+
+If this returns true, it means that the function is provided for any set of arguments with the given types. If it returns false, it may be provided for certain objects. For this reason, algorithm writers should call the `provided(f, args...)` version when possible.
+"""
+function provided end
+
+provided(f::Function, args...) = provided(f, typeof(args))
+provided(f::Function, ::Type{<:Tuple}) = false
+
+provided(::typeof(reset!), ::Type{<:Tuple{AbstractEnv}}) = true
+provided(::typeof(actions), ::Type{<:Tuple{AbstractEnv}}) = true
+provided(::typeof(observe), ::Type{<:Tuple{AbstractEnv}}) = true
+provided(::typeof(act!), ::Type{<:Tuple{AbstractEnv, Any}}) = true
+
+"""
+    @provide f(x::X) = x^2
+
+Indicate that function `f` has been implemented for arguments of type `X`.
+
+This will automatically implement the appropriate methods of `provided`. Both the long and short function definition forms will work.
+
+# Example
+```jldoctest
+using CommonRLInterface
+
+struct MyEnv <: AbstractEnv
+    s::Int
+end
+
+# Initially, clone is not provided
+@assert !provided(clone, MyEnv(1))
+
+@provide CommonRLInterface.clone(env::MyEnv) = MyEnv(env.s)
+
+@assert provided(clone, MyEnv(1))
+
+clone(MyEnv(1))
+
+# output
+
+MyEnv(1)
+
+```
+"""
+macro provide(f)
+    def = splitdef(f) # TODO: probably give a better error message that mentions @provide if this fails
+    @assert isempty(def[:kwargs]) "@provide does not support keyword args yet."
+    
+    func = esc(def[:name])
+
+    argtypes = []
+    for arg in def[:args]
+        if @capture(arg, name_::T_)
+            push!(argtypes, esc(T))
+        else
+            push!(argtypes, :Any)
+        end
+    end
+    
+    quote
+        CommonRLInterface.Optional.provided(::typeof($func), ::Type{<:Tuple{$(argtypes...)}}) where {$(map(esc, def[:whereparams])...)} = true
+
+        $(esc(f))
+    end
+end
+
+export
+    clone,
+    render,
+    state,
+    setstate!
+include("environment.jl")
+
+export
+    observations,
+    valid_actions,
+    valid_action_mask
+include("spaces.jl")
+
+export
+    players,
+    player,
+    all_act!,
+    all_observe,
+    UtilityStyle,
+    ZeroSum,
+    ConstantSum,
+    GeneralSum,
+    IdenticalUtility
+include("multiplayer.jl")

--- a/src/quick_wrapper.jl
+++ b/src/quick_wrapper.jl
@@ -72,13 +72,18 @@ _call(other, args...) = other
 @quick_forward CommonRLInterface.valid_actions
 @quick_forward CommonRLInterface.valid_action_mask
 @quick_forward CommonRLInterface.observations
+
+@quick_forward CommonRLInterface.players
 @quick_forward CommonRLInterface.player
+@quick_forward CommonRLInterface.all_act!
+@quick_forward CommonRLInterface.all_observe
+@quick_forward CommonRLInterface.UtilityStyle
 
 function CommonRLInterface.clone(w::QuickWrapper, args...)
     if haskey(w.data, :clone)
         QuickWrapper(_call(w.data[:clone], w.env), w.data)
     else
-        QuickWrapper(clone(w.env), w.data)
+        QuickWrapper(clone(w.env), deepcopy(w.data))
     end
 end
 

--- a/src/spaces.jl
+++ b/src/spaces.jl
@@ -1,14 +1,14 @@
 """
     valid_actions(env)
 
-Return a collection of actions that are appropriate for the current state. This should be a subset of actions(env).
+Return a collection of actions that are appropriate for the current state and player. This should be a subset of actions(env).
 """
 function valid_actions end
 
 """
     valid_action_mask(env)
 
-Return a mask (any `AbstractArray{Bool}`) indicating which actions are valid.
+Return a mask (any `AbstractArray{Bool}`) indicating which actions are valid at the current state and player.
 
 This function only applies to environments with finite action spaces. If both `valid_actions` and `valid_action_mask` are provided, `valid_actions(env)` should return the same set as `actions(env)[valid_action_mask(env)]`.
 """

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -49,7 +49,6 @@ end
 @forward_to_wrapped CommonRLInterface.act!
 @forward_to_wrapped CommonRLInterface.terminated
 
-@forward_to_wrapped CommonRLInterface.player
 
 @forward_to_wrapped CommonRLInterface.render
 @forward_to_wrapped CommonRLInterface.state
@@ -58,6 +57,12 @@ end
 @forward_to_wrapped CommonRLInterface.valid_action_mask
 @forward_to_wrapped CommonRLInterface.observations
 # not straightforward to provide clone
+
+@forward_to_wrapped CommonRLInterface.players
+@forward_to_wrapped CommonRLInterface.player
+@forward_to_wrapped CommonRLInterface.all_act!
+@forward_to_wrapped CommonRLInterface.all_observe
+@forward_to_wrapped CommonRLInterface.UtilityStyle
 
 CommonRLInterface.provided(f::Function, w::AbstractWrapper, args...) = provided(f, wrapped_env(w), args...)
 CommonRLInterface.provided(::typeof(clone), w::AbstractWrapper, args...) = false

--- a/test/default.jl
+++ b/test/default.jl
@@ -15,5 +15,14 @@
     @test actions(env)[D.valid_action_mask(env)] == actions(env)
     @test D.players(env) == 1
     @test D.player(env) == 1
-    @test D.UtilityStyle(env) == GeneralSum() # don't understand this one - it is not broken if I just include this file
+    @test D.UtilityStyle(env) == GeneralSum()
+
+    struct DefaultActionMaskTestEnv <: AbstractEnv
+        state::Int
+    end
+
+    CommonRLInterface.actions(::DefaultActionMaskTestEnv) = 1:3
+    CommonRLInterface.valid_actions(env::DefaultActionMaskTestEnv) = filter(!=(env.state), actions(env))
+    @test D.valid_actions(DefaultActionMaskTestEnv(1)) == 2:3
+    @test D.valid_action_mask(DefaultActionMaskTestEnv(1)) == [0,1,1]
 end

--- a/test/default.jl
+++ b/test/default.jl
@@ -1,0 +1,19 @@
+@testset "default" begin
+    struct DefaultTestEnv <: AbstractEnv end
+
+    CommonRLInterface.actions(::DefaultTestEnv) = (1,2)
+
+    import .AutomaticDefault
+
+    D = AutomaticDefault
+
+    env = DefaultTestEnv()
+
+    @test D.clone(env) == env
+    @test D.actions(env, 1) == actions(env)
+    @test D.valid_actions(env) == actions(env)
+    @test actions(env)[D.valid_action_mask(env)] == actions(env)
+    @test D.players(env) == 1
+    @test D.player(env) == 1
+    @test D.UtilityStyle(env) == GeneralSum() # don't understand this one - it is not broken if I just include this file
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using CommonRLInterface
 using Test
+using Documenter: doctest
+
+doctest(CommonRLInterface)
 
 mutable struct LQREnv <: AbstractEnv
     s::Float64

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -166,4 +166,6 @@ include("examples/gridworld.jl")
 include("examples/tictactoe.jl")
 include("examples/rock_paper_scissors.jl")
 
+include("default.jl")
+
 include("wrappers.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,7 @@ function CommonRLInterface.act!(env::MyGame, a)
     return -o^2
 end
 CommonRLInterface.player(env::MyGame) = 1 + iseven(env.state)
+CommonRLInterface.UtilityStyle(env::MyGame) = GeneralSum()
 game = MyGame()
 
 function f end
@@ -121,8 +122,10 @@ end
     @test !provided(clone, MyEnv())
     @test !provided(player, MyEnv())
     @test !provided(actions, MyEnv(), 1)
+    @test !provided(UtilityStyle, MyEnv())
 
     @test provided(player, MyGame())
+    @test provided(UtilityStyle, MyGame())
 end
 
 @testset "environment" begin
@@ -143,6 +146,8 @@ end
     env1 = MyEnv(0)
     setstate!(env1, 1)
     @test state(env1) == 1
+
+    @test !provided(UtilityStyle, MyEnv(0))
 end
 
 @testset "spaces" begin


### PR DESCRIPTION
This allows an algorithm writer to do, for example
```julia
using CommonRLInterface.AutomaticDefault: clone, valid_actions
```

Then clone will automatically try to use the `clone` provided by the environment, or fall back to `deepcopy`. Similarly `valid_actions` will use an environment's `valid_actions` or `valid_action_mask` or fall back to `actions`.

Still need to provide documentation. This will close #44 . I decided there was no need for an `Optional` module.