### PR TITLE
Minor Wrapper edits

### DIFF
--- a/docs/src/wrappers.md
+++ b/docs/src/wrappers.md
@@ -12,5 +12,5 @@ It is also possible to easily create custom wrapper types by subtyping [`Wrapper
 Wrappers.QuickWrapper
 Wrappers.AbstractWrapper
 Wrappers.wrapped_env
-Wrappers.base_env
+Wrappers.unwrapped
 ```

--- a/docs/src/wrappers.md
+++ b/docs/src/wrappers.md
@@ -11,4 +11,6 @@ It is also possible to easily create custom wrapper types by subtyping [`Wrapper
 ```@docs
 Wrappers.QuickWrapper
 Wrappers.AbstractWrapper
+Wrappers.wrapped_env
+Wrappers.base_env
 ```

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -6,7 +6,7 @@ export
     AbstractWrapper,
     QuickWrapper,
     wrapped_env,
-    base_env
+    unwrapped
 
 """
     AbstractWrapper
@@ -38,19 +38,26 @@ actions(w) # will now return [-1, 1]
 abstract type AbstractWrapper <: AbstractEnv end
 
 """
-Indicate what the wrapped environment is for an AbstractWrapper (see the AbstractWrapper docstring).
+    wrapped_env(env)
+
+Return the wrapped environment for an AbstractWrapper.
+
+This is a *required function* that must be provided by every AbstractWrapper.
+
+See also [`unwrapped`](@ref).
 """
 function wrapped_env end
 
 """
-Returns the recursively unwrapped environment.
+    unwrapped(env)
+
+Return the environment underneath all layers of wrappers.
+
+See also [wrapped_env`](@ref).
 """
-function base_env(env::AbstractWrapper)
-    while env isa AbstractWrapper
-        env = wrapped_env(env)
-    end
-    return env
-end
+unwrapped(env::AbstractWrapper) = unwrapped(wrapped_env(env))
+unwrapped(env::AbstractEnv) = env
+
 
 macro forward_to_wrapped(f)
     return :($f(w::AbstractWrapper, args...; kwargs...) = $f(wrapped_env(w), args...; kwargs...))

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -4,7 +4,9 @@ using CommonRLInterface
 
 export
     AbstractWrapper,
-    QuickWrapper
+    QuickWrapper,
+    wrapped_env,
+    base_env
 
 """
     AbstractWrapper
@@ -21,7 +23,7 @@ struct MyActionWrapper{E} <: AbstractWrapper
 end
     
 # Any subclass of AbstractWrapper MUST implement wrapped_env
-CommonRLInterface.wrapped_env(w::MyActionWrapper) = w.env
+Wrappers.wrapped_env(w::MyActionWrapper) = w.env
 
 # Now all CommonRLFunctions functions are forwarded
 w = MyActionWrapper(env)
@@ -33,12 +35,22 @@ CommonRLInterface.actions(w::MyActionWrapper) = [-1, 1]
 actions(w) # will now return [-1, 1]
 ```
 """
-abstract type AbstractWrapper end
+abstract type AbstractWrapper <: AbstractEnv end
 
 """
-Indicate what the wrapped environment is for an AbstractWrapper (see the AbstractWrapper docstring)
+Indicate what the wrapped environment is for an AbstractWrapper (see the AbstractWrapper docstring).
 """
 function wrapped_env end
+
+"""
+Returns the recursively unwrapped environment.
+"""
+function base_env(env::AbstractWrapper)
+    while env isa AbstractWrapper
+        env = wrapped_env(env)
+    end
+    return env
+end
 
 macro forward_to_wrapped(f)
     return :($f(w::AbstractWrapper, args...; kwargs...) = $f(wrapped_env(w), args...; kwargs...))


### PR DESCRIPTION
1. `AbstractWrapper` is now a subtype of `AbstractEnv`.
2. Added `base_env `, a recursive version of `wrapped_env`. 
3. Exported `wrapped_env` and `base_env ` for user convenience.
4. Updated docs.